### PR TITLE
Fix typos in "workstation" which prevent install

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -36,8 +36,8 @@ Install-ChocolateyZipPackage @LGPOPackageArgs
 if ($arguments.ContainsKey("OSType")) {
   Write-Host "OSType Argument Found"
   $OSType = $arguments["OSType"]
-  if ($OSType -notmatch "Server|Worstation"){
-    Throw "Arguments must be either 'server' or 'workstaiton'"
+  if ($OSType -notmatch "Server|Workstation"){
+    Throw "Arguments must be either 'server' or 'workstation'"
   }
 }
 else{


### PR DESCRIPTION
A small typo in the spelling of "Workstation" prevents installing Chocolatey-WinSecurityBaseline with that OSType parameter. A similar small typo in "workstation" on the following line presents a potentially confusing error message. I'm new to Chocolatey, and even to PowerShell, but I expect this would fix it.