### PR TITLE
Releases/v20.1809

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           name: choco-package
           path: ${{ github.workspace }}/
-u
+          
   Release:
     needs: Build
     if: contains(github.ref , 'releases') && github.event_name != 'pull_request'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,11 +36,11 @@ jobs:
         with:
           files: ${{ github.workspace }}/**/*.xml
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: choco-package
           path: ${{ github.workspace }}/
-
+u
   Release:
     needs: Build
     if: contains(github.ref , 'releases') && github.event_name != 'pull_request'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,8 +2,12 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - 'main'  
   push:
     branches:
+      - 'main'
       - 'releases/**'
       - 'bugs/**'
 
@@ -39,6 +43,7 @@ jobs:
 
   Release:
     needs: Build
+    if: contains(github.repository , 'releases')
     runs-on: windows-latest
     environment:
       name: Release

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate Tag
         shell: pwsh
         run: |
-          $branchName = "${{ github.ref }}" -replace 'refs/heads/', ''
+          $branchName = "${{ github.ref }}" -replace 'refs/heads/releases/', ''
           echo $branchName
           echo "CURRENT_BRANCH=${branchName}" >> $env:GITHUB_ENV
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -43,7 +43,7 @@ jobs:
 
   Release:
     needs: Build
-    if: contains(github.repository , 'releases')
+    if: contains(github.ref , 'releases') && github.event_name != 'pull_request'
     runs-on: windows-latest
     environment:
       name: Release

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -4,10 +4,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - 'main'  
+      - 'master'  
   push:
     branches:
-      - 'main'
+      - 'master'
       - 'releases/**'
       - 'bugs/**'
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,7 +48,7 @@ jobs:
     environment:
       name: Release
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: choco-package
           path: ${{ github.workspace }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,11 @@
 
 name: CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'releases/**'
+      - 'bugs/**'
 
 jobs:
   Build:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,6 +26,7 @@ The following package parameters can be set:
 
 #### Package Versions
 |Windows Version|Choco Package Version|
+|---|---|
 |Windows Server 2019 LTSC - 1803|18.9.0|
 
 ## Using security baselines in your organization 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -28,6 +28,7 @@ The following package parameters can be set:
 |Windows Version|Choco Package Version|
 |---|---|
 |Windows Server 2019 LTSC - 1803|18.9.0|
+|Windows 10 LTSC - 1803|18.9.0|
 
 ## Using security baselines in your organization 
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -27,8 +27,8 @@ The following package parameters can be set:
 #### Package Versions
 |Windows Version|Choco Package Version|
 |---|---|
-|Windows Server 2019 LTSC - 1803|18.9.0|
-|Windows 10 LTSC - 1803|18.9.0|
+|Windows Server 2019 LTSC - 1803|20.1803|
+|Windows 10 LTSC - 1803|20.1803|
 
 ## Using security baselines in your organization 
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -18,11 +18,15 @@ C:\choco upgrade winsecuritybaseline
 #### Package Parameters
 The following package parameters can be set:
 
- * `/OSType:workstation\server` - Default values is server 
+ * `/OSType:workstation\server` - Default value is server 
 
 #### Package Uninstallation
 
  * Package LGPO settings cannot be uninsalled programticall once installed. This need to be done manually!
+
+#### Package Versions
+|Windows Version|Choco Package Version|
+|Windows Server 2019 LTSC - 1803|18.9.0|
 
 ## Using security baselines in your organization 
 

--- a/WinSecurityBaseline.Pester.ps1
+++ b/WinSecurityBaseline.Pester.ps1
@@ -8,7 +8,9 @@ Install-Module -Name Pester -MinimumVersion 5.2.2 -Confirm:$false -Force
 
 $outputFile = "$PSScriptRoot\Pester-Tests.xml"
 
-$pesterConfigurationContainer = New-PesterContainer -Path "WinSecurityBaseline.Tests.ps1" -Data @{PackageName = 'WinSecurityBaseline'}
+$nuspec= [xml](Get-Content "$PSScriptRoot\WinSecurityBaseline.nuspec")
+
+$pesterConfigurationContainer = New-PesterContainer -Path "WinSecurityBaseline.Tests.ps1" -Data @{PackageName = 'WinSecurityBaseline'; PackageVersion = $nuspec.package.metadata.version}
 
 $pesterConfiguration = [PesterConfiguration]::Default
 $pesterConfiguration.Run.Container = $pesterConfigurationContainer

--- a/WinSecurityBaseline.Tests.ps1
+++ b/WinSecurityBaseline.Tests.ps1
@@ -1,12 +1,18 @@
 param(
     [Parameter(Mandatory = $true)]
-    [string]$PackageName = 'WinSecurityBaseline'
+    [string]$PackageName,
+    [Parameter(Mandatory = $true)]
+    [string]$PackageVersion
 )
 
 
-if (!(choco --version)) {
+$Choco = choco --version
+if (!$Choco) {
     Write-Host "Choco not installed - Installing..."
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+}
+elseif ($Choco -lt '2.0.0') {
+    choco upgrade chocolatey
 }
 
 $WorkingFiles = Get-ChildItem -Recurse
@@ -23,10 +29,10 @@ Write-Host $ChocoLogs
 #>
 
 Describe 'Chocolatey Packages Install' {
-    It "Install: $PackageName" -TestCases @{PackageName = $PackageName; Nupkg = $Nupkg}  {
+    It "Install: $PackageName" -TestCases @{PackageName = $PackageName; PackageVersion = $PackageVersion; Nupkg = $Nupkg}  {
         $PkgInstall = $null
-        $PkgInstall = choco install $PackageName --version="18.9.0" --source="$PSScriptRoot"
-        Write-Host $PkgInstall 
+        $PkgInstall = choco install $PackageName --version="$PackageVersion" --source="$PSScriptRoot"
+        Write-Host $PkgInstall
         Write-Host $PSScriptRoo
         $PkgInstall | Where-Object {$_ -match "The install of $PackageName was successful"} | Should -Not -Be $null
     }

--- a/WinSecurityBaseline.Tests.ps1
+++ b/WinSecurityBaseline.Tests.ps1
@@ -1,5 +1,5 @@
 param(
-    [Parameter(Mandatory = $false)]
+    [Parameter(Mandatory = $true)]
     [string]$PackageName = 'WinSecurityBaseline'
 )
 
@@ -25,7 +25,7 @@ Write-Host $ChocoLogs
 Describe 'Chocolatey Packages Install' {
     It "Install: $PackageName" -TestCases @{PackageName = $PackageName; Nupkg = $Nupkg}  {
         $PkgInstall = $null
-        $PkgInstall = choco install $Nupkg.FullName -y
+        $PkgInstall = choco install $PackageName --version="18.9.0" --source="$PSScriptRoot"
         $PkgInstall | Where-Object {$_ -match "The install of $PackageName was successful"} | Should -Not -Be $null
     }
 }

--- a/WinSecurityBaseline.Tests.ps1
+++ b/WinSecurityBaseline.Tests.ps1
@@ -26,6 +26,8 @@ Describe 'Chocolatey Packages Install' {
     It "Install: $PackageName" -TestCases @{PackageName = $PackageName; Nupkg = $Nupkg}  {
         $PkgInstall = $null
         $PkgInstall = choco install $PackageName --version="18.9.0" --source="$PSScriptRoot"
+        Write-Host $PkgInstall 
+        Write-Host $PSScriptRoo
         $PkgInstall | Where-Object {$_ -match "The install of $PackageName was successful"} | Should -Not -Be $null
     }
 }

--- a/WinSecurityBaseline.Tests.ps1
+++ b/WinSecurityBaseline.Tests.ps1
@@ -33,7 +33,7 @@ Describe 'Chocolatey Packages Install' {
 Describe 'Chocolatey Package is listed' {
     It "Listed" -TestCases @{PackageName = $PackageName} {
         $PkgList = $null
-        $PkgList = choco list --local-only
+        $PkgList = choco list
         $PkgList | Where-Object {$_ -match $PackageName} | Should -Not -Be $null
     }
 }

--- a/WinSecurityBaseline.Tests.ps1
+++ b/WinSecurityBaseline.Tests.ps1
@@ -32,8 +32,8 @@ Describe 'Chocolatey Packages Install' {
     It "Install: $PackageName" -TestCases @{PackageName = $PackageName; PackageVersion = $PackageVersion; Nupkg = $Nupkg}  {
         $PkgInstall = $null
         $PkgInstall = choco install $PackageName --version="$PackageVersion" --source="$PSScriptRoot"
-        Write-Host $PkgInstall
-        Write-Host $PSScriptRoo
+        #Write-Host $PkgInstall
+        #Write-Host $PSScriptRoo
         $PkgInstall | Where-Object {$_ -match "The install of $PackageName was successful"} | Should -Not -Be $null
     }
 }

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>WinSecurityBaseline</id>
-    <version>18.9.0</version>
+    <version>20.1803</version>
     <packageSourceUrl>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline</packageSourceUrl>
     <owners>devnoadic</owners>
     <title>WinSecurityBaseline</title>
@@ -34,8 +34,8 @@ The following package parameters can be set:
 
 #### Package Versions
 |Windows Version|Choco Package Version|
-|Windows Server 2019 LTSC - 1803|18.9.0|
-|Windows 10 LTSC - 1803|18.9.0|
+|Windows Server 2019 LTSC - 1803|20.1803|
+|Windows 10 LTSC - 1803|20.1803|
 
 ## Using security baselines in your organization 
 

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>WinSecurityBaseline</id>
-    <version>18.09</version>
+    <version>18.9.0</version>
     <packageSourceUrl>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline</packageSourceUrl>
     <owners>devnoadic</owners>
     <title>WinSecurityBaseline</title>

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -32,6 +32,10 @@ The following package parameters can be set:
 
  * Package LGPO settings cannot be uninsalled programticall once installed. This need to be done manually!
 
+#### Package Versions
+|Windows Version|Choco Package Version|
+|Windows Server 2019 LTSC - 1803|18.9.0|
+
 ## Using security baselines in your organization 
 
 Microsoft is dedicated to providing its customers with secure operating systems, such as Windows 10 and Windows Server, and secure apps, such as Microsoft Edge. In addition to the security assurance of its products, Microsoft also enables you to have fine control over your environments by providing various configuration capabilities. 

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -35,6 +35,7 @@ The following package parameters can be set:
 #### Package Versions
 |Windows Version|Choco Package Version|
 |Windows Server 2019 LTSC - 1803|18.9.0|
+|Windows 10 LTSC - 1803|18.9.0|
 
 ## Using security baselines in your organization 
 

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>WinSecurityBaseline</id>
-    <version>19.03.02</version>
+    <version>18.09</version>
     <packageSourceUrl>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline</packageSourceUrl>
     <owners>devnoadic</owners>
     <title>WinSecurityBaseline</title>
@@ -13,20 +13,20 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-security-configuration-framework</projectSourceUrl>
     <docsUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-security-configuration-framework/windows-security-baselines.md</docsUrl>
-    <tags>Windows Security Baseline 1903</tags>
+    <tags>Windows Security Baseline 1809</tags>
     <summary>A security baseline is a group of Microsoft-recommended configuration settings that explains their security impact. These settings are based on feedback from Microsoft security engineering teams, product groups, partners, and customers.</summary>
     <description>
 # Windows security baselines
 
 **Applies to**
 -   Windows Server 2016+
--   Windows 10
+-   Windows 10+
 
 ### Package Specific
 #### Package Parameters
 The following package parameters can be set:
 
- * `/OSType:workstation\server` - Default values is server 
+ * `/OSType:workstation\server` - Default value is server 
 
 #### Package Uninstallation
 

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -13,6 +13,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-security-configuration-framework</projectSourceUrl>
     <docsUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-security-configuration-framework/windows-security-baselines.md</docsUrl>
+    <releaseNotes>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline/pull/7</releaseNotes>
     <tags>Windows Security Baseline 1809</tags>
     <summary>A security baseline is a group of Microsoft-recommended configuration settings that explains their security impact. These settings are based on feedback from Microsoft security engineering teams, product groups, partners, and customers.</summary>
     <description>

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -11,8 +11,8 @@
     <iconUrl>https://rawcdn.githack.com/devnomadic/Chocolatey-WinSecurityBaseline/6c9feb19bd88c5016b10b82947c97bfc4ab8f1de/MS_SecurityIntelligence_Icon.png</iconUrl>
     <licenseUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <projectSourceUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-security-configuration-framework</projectSourceUrl>
-    <docsUrl>https://github.com/MicrosoftDocs/windows-itpro-docs/blob/public/windows/security/threat-protection/windows-security-configuration-framework/windows-security-baselines.md</docsUrl>
+    <projectSourceUrl>https://www.microsoft.com/en-us/download/details.aspx?id=55319</projectSourceUrl>
+    <docsUrl>https://techcommunity.microsoft.com/t5/microsoft-security-baselines/bg-p/Microsoft-Security-Baselines</docsUrl>
     <releaseNotes>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline/pull/7</releaseNotes>
     <tags>Windows Security Baseline 1809</tags>
     <summary>A security baseline is a group of Microsoft-recommended configuration settings that explains their security impact. These settings are based on feedback from Microsoft security engineering teams, product groups, partners, and customers.</summary>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build: false
 test_script:
     - ps: |
         $outputFile = ".\Pester-Tests.xml"
-        .\WinSecurityBaseline.Pester.ps1 -OutputFormat "XUnitXml"
+        .\WinSecurityBaseline.Pester.ps1 -OutputFormat "NUnitXml"
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $outputFile))
     
 #---------------------------------# 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build: false
 test_script:
     - ps: |
         $outputFile = ".\Pester-Tests.xml"
-        .\WinSecurityBaseline.Pester.ps1 -OutputFormat "JUnitXml"
+        .\WinSecurityBaseline.Pester.ps1 -OutputFormat "XUnitXml"
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $outputFile))
     
 #---------------------------------# 

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -22,7 +22,7 @@ $SecBaseLinePackageArgs = @{
 
 $LGPOPackageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  unzipLocation = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Scripts\Tools"
+  unzipLocation = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools"
   url           = $LGPOUrl
   checksum      = 'CB7159D134A0A1E7B1ED2ADA9A3CE8CE8F4DE391D14403D55438AF824247CC55'
   checksumType  = 'sha256'
@@ -33,10 +33,10 @@ Install-ChocolateyZipPackage @SecBaseLinePackageArgs
 Install-ChocolateyZipPackage @LGPOPackageArgs
 
 #If unzip does not place LPGO.exe in tools directory then move it
-if (!(Test-Path -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Scripts\Tools\LGPO.exe")){
-    $gci = Get-ChildItem -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Scripts\Tools\" -Filter '*LGPO.exe' -Recurse
+if (!(Test-Path -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools\LGPO.exe")){
+    $gci = Get-ChildItem -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools\" -Filter '*LGPO.exe' -Recurse
     if ($gci){
-        Move-Item -Path $gci[0].FullName -Destination "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Scripts\Tools\$($gci.name)"
+        Move-Item -Path $gci[0].FullName -Destination "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools\$($gci.name)"
     }
     else{
         throw "Unable to find LGPO.exe"
@@ -55,10 +55,10 @@ else{
   $OSType = 'Server'
 } 
 
-$ScriptInstallerPath = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Baseline-LocalInstall.ps1"
+$ScriptInstallerPath = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\BaselineLocalInstall.ps1"
 
 if ($OSType -eq 'Server'){
-  & $ScriptInstallerPath -WSNonDomainJoined
+  & $ScriptInstallerPath -WS2019NonDomainJoined
 }
 elseif ($OSType -eq 'Workstation'){
   & $ScriptInstallerPath -Win10NonDomainJoined

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -8,14 +8,14 @@ if($OSVersion.Major -lt 10){
   throw "Windows build must be Windows10+ or Server2016+"
 }
 
-$SecBaseLineUrl = 'https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/Windows%2010%20Version%201903%20and%20Windows%20Server%20Version%201903%20Security%20Baseline%20-%20Sept2019Update.zip' # download url, HTTPS preferred
+$SecBaseLineUrl = 'https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/Windows%2010%20Version%201809%20and%20Windows%20Server%202019%20Security%20Baseline.zip' # download url, HTTPS preferred
 $LGPOUrl        = 'https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/LGPO.zip'
 
 $SecBaseLinePackageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName"
   url           = $SecBaseLineUrl
-  checksum      = 'F51FC91A6E5CEEE9D965F2D12319DEFA25073101421D212F95F40A402DDA7740'
+  checksum      = '575DDAF39EF364EA6DA678E22B0A988EA316EB240F73FBF618092A02647245BC'
   checksumType  = 'sha256'
   silentArgs    = ''
 }
@@ -55,7 +55,7 @@ else{
   $OSType = 'Server'
 } 
 
-$ScriptInstallerPath = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Scripts\Baseline-LocalInstall.ps1"
+$ScriptInstallerPath = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Baseline-LocalInstall.ps1"
 
 if ($OSType -eq 'Server'){
   & $ScriptInstallerPath -WSNonDomainJoined

--- a/tools/chocolateyuninstall.ps1
+++ b/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  ZipFileName   = 'Windows 10 Version 1903 and Windows Server Version 1903 Security Baseline - Sept2019Update.zip'
+  ZipFileName   = 'Windows 10 Version 1809 and Windows Server 2019 Security Baseline.zip'
 }
 
 Uninstall-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
This pull request includes several updates to the CI workflow, package configuration, and test scripts for the `WinSecurityBaseline` project. The changes aim to improve the build process, update dependencies, and enhance the package's metadata and testing procedures.

### CI Workflow Updates:
* [`.github/workflows/actions.yml`](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL4-R12): Modified the workflow to trigger on pull requests to the `master` branch and on pushes to `master`, `releases/**`, and `bugs/**` branches. Updated `actions/upload-artifact` and `actions/download-artifact` to version 4. Added a condition to the `Release` job to run only if the event is not a pull request. [[1]](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL4-R12) [[2]](diffhunk://#diff-2702f6f7d10a1bffbc8596d1a9925b1234bc4c7a6ff4c21ca6b34c13aa75780eL31-R51)

### Package Configuration Updates:
* [`WinSecurityBaseline.nuspec`](diffhunk://#diff-a4e39064f0bd60eb1e500293ebca3f06d0091420397f7c4671907f629d2c4335L5-R5): Updated the package version to `20.1803` and the security baseline tags to `1809`. Added a table listing Windows versions and their corresponding Choco package versions. [[1]](diffhunk://#diff-a4e39064f0bd60eb1e500293ebca3f06d0091420397f7c4671907f629d2c4335L5-R5) [[2]](diffhunk://#diff-a4e39064f0bd60eb1e500293ebca3f06d0091420397f7c4671907f629d2c4335L16-R39)
* [`tools/chocolateyinstall.ps1`](diffhunk://#diff-8e2a00a232615d1e1e8f1aa45c6a527e554ff98937b6b9184e86bb74e793cb7aL11-R25): Updated the security baseline URL and checksum to the 1809 version. Changed the LGPO tool's unzip location and adjusted paths accordingly. [[1]](diffhunk://#diff-8e2a00a232615d1e1e8f1aa45c6a527e554ff98937b6b9184e86bb74e793cb7aL11-R25) [[2]](diffhunk://#diff-8e2a00a232615d1e1e8f1aa45c6a527e554ff98937b6b9184e86bb74e793cb7aL36-R39) [[3]](diffhunk://#diff-8e2a00a232615d1e1e8f1aa45c6a527e554ff98937b6b9184e86bb74e793cb7aL58-R61)
* [`tools/chocolateyuninstall.ps1`](diffhunk://#diff-68a50320b9fbb0a58918b85b0ad96db7ce253714caa9e4b6046b14ff6f2a5b28L5-R5): Updated the uninstall script to reference the 1809 security baseline zip file.

### Test Script Enhancements:
* [`WinSecurityBaseline.Pester.ps1`](diffhunk://#diff-0335c4eed199d6ef1408d598f2fb7f319e8322d83ad2111fab626ec36f0732d4L11-R13): Added logic to read the package version from `WinSecurityBaseline.nuspec` and include it in the Pester test container.
* [`WinSecurityBaseline.Tests.ps1`](diffhunk://#diff-af252edafb1d1c052f73ee249b6dc2fef4e780fc108e4f5b6d348e21c581cb35L2-R16): Made `PackageName` and `PackageVersion` parameters mandatory. Added logic to upgrade Chocolatey if the version is less than 2.0.0. Updated test cases to include `PackageVersion`. [[1]](diffhunk://#diff-af252edafb1d1c052f73ee249b6dc2fef4e780fc108e4f5b6d348e21c581cb35L2-R16) [[2]](diffhunk://#diff-af252edafb1d1c052f73ee249b6dc2fef4e780fc108e4f5b6d348e21c581cb35L26-R44)

### Documentation Updates:
* [`ReadMe.md`](diffhunk://#diff-0b59e9c9f474883e24cb1319da596e81aa164472c07d90db0df74948792cf6cbL21-R32): Corrected a typo in the package parameters section and added a table listing Windows versions and their corresponding Choco package versions.

### Miscellaneous:
* [`appveyor.yml`](diffhunk://#diff-92ab9a36df5d8e9f7076f2fdec59492d1ac2d9cf27ea046767a7fc4d542ef3dcL30-R30): Changed the test script output format from `JUnitXml` to `NUnitXml`.