### PR TITLE
Add Windows Server 2022 Security Baseline support (#10)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   Build:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v2
 
@@ -31,7 +31,7 @@ jobs:
           .\WinSecurityBaseline.Pester.ps1 -OutputFormat "JUnitXml"
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
         if: always()
         with:
           files: ${{ github.workspace }}/**/*.xml

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,8 @@
 ﻿## Build Status
-[![Build status](https://ci.appveyor.com/api/projects/status/a30xsob1g3xp5jog?svg=true)](https://ci.appveyor.com/project/devnomadic/chocolatey-winsecuritybaseline) [![actions workflow](https://github.com/devnomadic/chocolatey-winsecuritybaseline/actions/workflows/actions.yml/badge.svg)](https://github.com/devnomadic/chocolatey-winsecuritybaseline/actions)
+|Appveyor Build|GitHub Build|
+|---|---|
+|[![Build status](https://ci.appveyor.com/api/projects/status/a30xsob1g3xp5jog?svg=true)](https://ci.appveyor.com/project/devnomadic/chocolatey-winsecuritybaseline) | [![actions workflow](https://github.com/devnomadic/chocolatey-winsecuritybaseline/actions/workflows/actions.yml/badge.svg)](https://github.com/devnomadic/chocolatey-winsecuritybaseline/actions)|
+|Win2019 Only|Win2022+|
 
 # Windows security baselines
 
@@ -11,8 +14,8 @@ C:\choco upgrade winsecuritybaseline
 ```
 
 **Applies to**
--   Windows Server 2016+
--   Windows 10
+-   Windows Server 2022+
+-   Windows 10+
 
 ### Package Specific
 #### Package Parameters
@@ -22,11 +25,13 @@ The following package parameters can be set:
 
 #### Package Uninstallation
 
- * Package LGPO settings cannot be uninsalled programticall once installed. This need to be done manually!
+ * Package LGPO settings cannot be uninstalled programmatically once installed. This needs to be done manually!
 
 #### Package Versions
 |Windows Version|Choco Package Version|
 |---|---|
+|Windows Server 2022 LTSC|22.0.0|
+|Windows 10 21H2|22.0.0|
 |Windows Server 2019 LTSC - 1803|20.1803|
 |Windows 10 LTSC - 1803|20.1803|
 

--- a/WinSecurityBaseline.nuspec
+++ b/WinSecurityBaseline.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>WinSecurityBaseline</id>
-    <version>20.1803</version>
+    <version>22.0.0</version>
     <packageSourceUrl>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline</packageSourceUrl>
     <owners>devnoadic</owners>
     <title>WinSecurityBaseline</title>
@@ -13,14 +13,14 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://www.microsoft.com/en-us/download/details.aspx?id=55319</projectSourceUrl>
     <docsUrl>https://techcommunity.microsoft.com/t5/microsoft-security-baselines/bg-p/Microsoft-Security-Baselines</docsUrl>
-    <releaseNotes>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline/pull/7</releaseNotes>
-    <tags>Windows Security Baseline 1809</tags>
+    <releaseNotes>https://github.com/devnomadic/Chocolatey-WinSecurityBaseline/releases</releaseNotes>
+    <tags>Windows Security Baseline 2022 Server</tags>
     <summary>A security baseline is a group of Microsoft-recommended configuration settings that explains their security impact. These settings are based on feedback from Microsoft security engineering teams, product groups, partners, and customers.</summary>
     <description>
 # Windows security baselines
 
 **Applies to**
--   Windows Server 2016+
+-   Windows Server 2022+
 -   Windows 10+
 
 ### Package Specific
@@ -31,12 +31,13 @@ The following package parameters can be set:
 
 #### Package Uninstallation
 
- * Package LGPO settings cannot be uninsalled programticall once installed. This need to be done manually!
+ * Package LGPO settings cannot be uninstalled programmatically once installed. This needs to be done manually!
 
 #### Package Versions
-|Windows Version|Choco Package Version|
-|Windows Server 2019 LTSC - 1803|20.1803|
-|Windows 10 LTSC - 1803|20.1803|
+Windows Server 2022 LTSC | 22.0.0
+Windows 10 21H2 | 22.0.0 
+Windows Server 2019 LTSC - 1803 | 20.1803
+Windows 10 LTSC - 1803 | 20.1803
 
 ## Using security baselines in your organization 
 

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -4,25 +4,27 @@ $arguments = Get-PackageParameters
 
 $OSVersion = [System.Environment]::OSVersion.Version
 
-if($OSVersion.Major -lt 10){
-  throw "Windows build must be Windows10+ or Server2016+"
+# Windows Server 2022 has build 20348, Windows 11 has build 22000+
+# This check excludes Windows 10 (builds < 20348) and Windows Server 2019 (build 17763)
+if($OSVersion.Major -lt 10 -or $OSVersion.Build -lt 20348){
+  throw "Windows build must be Windows 11+ or Windows Server 2022+"
 }
 
-$SecBaseLineUrl = 'https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/Windows%2010%20Version%201809%20and%20Windows%20Server%202019%20Security%20Baseline.zip' # download url, HTTPS preferred
+$SecBaseLineUrl = 'https://download.microsoft.com/download/8/5/c/85c25433-a1b0-4ffa-9429-7e023e7da8d8/Windows%20Server%202022%20Security%20Baseline.zip' # download url, HTTPS preferred
 $LGPOUrl        = 'https://download.microsoft.com/download/8/5/C/85C25433-A1B0-4FFA-9429-7E023E7DA8D8/LGPO.zip'
 
 $SecBaseLinePackageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName"
   url           = $SecBaseLineUrl
-  checksum      = '575DDAF39EF364EA6DA678E22B0A988EA316EB240F73FBF618092A02647245BC'
+  checksum      = '49590CC694626D171FC934FAFEA6494F13ECD3843086704B7A5B98355909B8E0'
   checksumType  = 'sha256'
   silentArgs    = ''
 }
 
 $LGPOPackageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  unzipLocation = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools"
+  unzipLocation = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Windows Server-2022-Security-Baseline-FINAL\Scripts\Tools"
   url           = $LGPOUrl
   checksum      = 'CB7159D134A0A1E7B1ED2ADA9A3CE8CE8F4DE391D14403D55438AF824247CC55'
   checksumType  = 'sha256'
@@ -33,10 +35,10 @@ Install-ChocolateyZipPackage @SecBaseLinePackageArgs
 Install-ChocolateyZipPackage @LGPOPackageArgs
 
 #If unzip does not place LPGO.exe in tools directory then move it
-if (!(Test-Path -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools\LGPO.exe")){
-    $gci = Get-ChildItem -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools\" -Filter '*LGPO.exe' -Recurse
+if (!(Test-Path -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Windows Server-2022-Security-Baseline-FINAL\Scripts\Tools\LGPO.exe")){
+    $gci = Get-ChildItem -Path "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\" -Filter '*LGPO.exe' -Recurse
     if ($gci){
-        Move-Item -Path $gci[0].FullName -Destination "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\Tools\$($gci.name)"
+        Move-Item -Path $gci[0].FullName -Destination "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Windows Server-2022-Security-Baseline-FINAL\Scripts\Tools\$($gci.name)"
     }
     else{
         throw "Unable to find LGPO.exe"
@@ -55,10 +57,11 @@ else{
   $OSType = 'Server'
 } 
 
-$ScriptInstallerPath = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Local_Script\BaselineLocalInstall.ps1"
+$ScriptInstallerPath = "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Windows Server-2022-Security-Baseline-FINAL\Scripts\Baseline-LocalInstall.ps1"
+cd "${env:ProgramFiles(x86)}\$env:ChocolateyPackageName\Windows Server-2022-Security-Baseline-FINAL\Scripts\"
 
 if ($OSType -eq 'Server'){
-  & $ScriptInstallerPath -WS2019NonDomainJoined
+  & $ScriptInstallerPath -WSNonDomainJoined
 }
 elseif ($OSType -eq 'Workstation'){
   & $ScriptInstallerPath -Win10NonDomainJoined

--- a/tools/chocolateyuninstall.ps1
+++ b/tools/chocolateyuninstall.ps1
@@ -2,7 +2,7 @@
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
-  ZipFileName   = 'Windows 10 Version 1809 and Windows Server 2019 Security Baseline.zip'
+  ZipFileName   = 'Windows Server 2022 Security Baseline.zip'
 }
 
 Uninstall-ChocolateyZipPackage @packageArgs


### PR DESCRIPTION
* Initial plan

* Add Windows Server 2022 Security Baseline support



* Update OS version check to require Windows 11+ or Windows Server 2022+



* Improve OS version check comment for clarity



* Fix URLs

* Update paths and checksums for Chocolatey install script

* Update runner version to windows-2022

* Update publish-unit-test-result-action to v2

* Update action to use Windows version for publishing results

* Revise build status table and fix typos

Updated build status section and corrected typos.

* Fix typos and update Windows version information

Corrected typos and updated Windows version details.

---------